### PR TITLE
gh-14: update photometric redshift distributions

### DIFF
--- a/euclidlib/_util.py
+++ b/euclidlib/_util.py
@@ -1,0 +1,27 @@
+"""
+Module for internal utility functions.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, TypeVar
+
+    AnyT = TypeVar("AnyT", bound=Any)
+
+
+def writer(func: Any) -> Callable[[AnyT], AnyT]:
+    """
+    Decorator for writer functions.
+    """
+
+    def decorator(writer: AnyT) -> AnyT:
+        func.write = writer
+        writer.__module__ = func.__module__
+        writer.__name__ = "write"
+        writer.__qualname__ = f"{func.__qualname__}.write"
+        return writer
+
+    return decorator

--- a/euclidlib/photo/_phz.py
+++ b/euclidlib/photo/_phz.py
@@ -33,7 +33,9 @@ def write_nz(
     hist: bool = False,
 ) -> None:
     """
-    Write n(z) data in Euclid SGS format.
+    Write n(z) data in Euclid SGS format.  Supports both distributions
+    (when *hist* is false, the default) and histograms (when *hist* is
+    true).
     """
 
     z = np.asanyarray(z)

--- a/euclidlib/photo/_phz.py
+++ b/euclidlib/photo/_phz.py
@@ -25,7 +25,7 @@ def _hist2dist(x: NDArray[Any], y: NDArray[Any]) -> NDArray[Any]:
 
 # this is the dtype for n(z) data in the Euclid SGS format
 NZ_DTYPE = [
-    ("BIN_ID", ">i8"),
+    ("BIN_ID", ">i4"),
     ("MEAN_REDSHIFT", ">f4"),
     ("N_Z", ">f4", (3000,)),
 ]

--- a/euclidlib/photo/_phz.py
+++ b/euclidlib/photo/_phz.py
@@ -74,14 +74,13 @@ def write_nz(
     if hist:
         # rebin the histogram as necessary
 
-        # compute the mean redshifts
-        zbar = (z[..., :-1] + z[..., 1:]) / 2
-        out["MEAN_REDSHIFT"] = np.sum(zbar * nz, axis=-1) / np.sum(nz, axis=-1)
-
         # shorthand for the left and right z boundaries, respectively
         zl, zr = z[:-1], z[1:]
 
-        # compute resummed bin counts in each bins
+        # compute the mean redshifts
+        out["MEAN_REDSHIFT"] = np.sum((zl + zr) / 2 * nz, axis=-1) / np.sum(nz, axis=-1)
+
+        # compute resummed bin counts
         for j, (z1, z2) in enumerate(zip(zbinedges, zbinedges[1:])):
             frac = (np.clip(z2, zl, zr) - np.clip(z1, zl, zr)) / (zr - zl)
             out["N_Z"][:, j] = np.dot(nz, frac)

--- a/euclidlib/photo/_phz.py
+++ b/euclidlib/photo/_phz.py
@@ -2,17 +2,106 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from os import PathLike
-from typing import Any
+from typing import TYPE_CHECKING
 
 import fitsio  # type: ignore [import-not-found]
 import numpy as np
-from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from typing import Any
+    from numpy.typing import ArrayLike, NDArray
+
+
+def _hist2dist(x: NDArray[Any], y: NDArray[Any]) -> NDArray[Any]:
+    """
+    Convert histogram to distribution.
+    """
+    *dims, n = y.shape
+    z = np.zeros((*dims, n + 1), dtype=y.dtype.base)
+    np.cumsum(y, axis=-1, out=z[..., 1:])
+    result: NDArray[Any] = np.gradient(z, x, axis=-1, edge_order=1)
+    return result
+
+
+# this is the dtype for n(z) data in the Euclid SGS format
+NZ_DTYPE = [
+    ("BIN_ID", ">i8"),
+    ("MEAN_REDSHIFT", ">f4"),
+    ("N_Z", ">f4", (3000,)),
+]
+
+
+def write_nz(
+    path: str | PathLike[str],
+    z: ArrayLike,
+    nz: ArrayLike,
+    *,
+    weight_method: str = "NO_WEIGHT",
+    bin_type: str = "TOM_BIN",
+    hist: bool = False,
+) -> None:
+    """
+    Write n(z) data in Euclid SGS format.
+    """
+
+    z = np.asanyarray(z)
+    nz = np.asanyarray(nz)
+
+    if z.ndim != 1:
+        raise ValueError("redshift array must be 1D")
+
+    if not hist and z.shape[-1] == nz.shape[-1]:
+        pass
+    elif hist and z.shape[-1] == nz.shape[-1] + 1:
+        nz = _hist2dist(z, nz)
+    else:
+        raise ValueError("shape mismatch between redshifts and values")
+
+    # PHZ uses a fixed binning scheme with z bins in [0, 6] and dz=0.002
+    zbinedges = np.linspace(0.0, 6.0, 3001, dtype=np.float32)
+
+    # compute the combined set of z grid points from data and binning
+    zp = np.union1d(z, zbinedges)
+
+    # create the output data in the correct format
+    dims = nz.shape[:-1]
+    nbin = np.prod(dims, dtype=int)
+    out = np.empty(nbin, dtype=NZ_DTYPE)
+
+    # convert every nz into the PHZ format
+    for i, index in enumerate(np.ndindex(*dims)):
+        # compute mean redshift
+        mean_z = np.trapz(z * nz[index], z)
+
+        # interpolate dndz onto the unified grid
+        nzp = np.interp(zp, z, nz[index], left=0.0, right=0.0)
+
+        # integrate the number of sources in each bin
+        n_z = []
+        for z1, z2 in zip(zbinedges, zbinedges[1:]):
+            sel = (z1 <= zp) & (zp <= z2)
+            n_z.append(np.trapz(nzp[sel], zp[sel]))
+
+        # set the output data row
+        out[i] = (i + 1, mean_z, n_z)
+
+    # metadata
+    header = {
+        "WEIGHT_METHOD": weight_method,
+        "BIN_TYPE": bin_type,
+        "NBIN": nbin,
+    }
+
+    # write output data to FITS
+    with fitsio.FITS(path, "rw", clobber=True) as fits:
+        fits.write(out, extname="BIN_INFO", header=header)
 
 
 def redshift_distributions(
     path: str | PathLike[str],
     *,
-    ext: str | int | None = None,
+    ext: str | int | None = "BIN_INFO",
+    hist: bool = False,
 ) -> tuple[NDArray[Any], Mapping[int, NDArray[Any]]]:
     """Read redshift distributions in Euclid format.
 
@@ -20,17 +109,20 @@ def redshift_distributions(
     ----------
     path : str
         Path to a FITS file in Euclid format.
-    ext : str or int, optional
-        The FITS extension to read.  By default, the first extension
+    ext : str or int or None, optional
+        The FITS extension to read.  If ``None``, the first extension
         with data is used.
+    hist : bool, optional
+        By default, the histograms are converted to distributions.  If
+        true, return the redshift histograms unmodified.
 
     Returns
     -------
     z : ndarray
-        Redshift bin edges of the redshift distribution histograms.
-    nzdict : dict of int and ndarray
+        Redshift values.
+    nz: dict of int and ndarray
         Dictionary where keys are tomographic bin IDs and values are the
-        histograms of the redshift distributions.
+        redshift distributions.
 
     """
 
@@ -38,7 +130,7 @@ def redshift_distributions(
     data = fitsio.read(path, ext=ext, lower=True)
 
     # this is the fixed binning scheme used by PHZ
-    z = np.arange(0.0, 6.001, 0.002)
+    z = np.linspace(0.0, 6.0, 3001)
 
     # check format
     shape = (z.size - 1,)
@@ -47,9 +139,11 @@ def redshift_distributions(
         raise ValueError(msg)
 
     # read each n(z) histogram into a dict
-    nz_dict = {}
+    out = {}
     for row in data:
         bin_id, n_z = row["bin_id"], row["n_z"]
-        nz_dict[bin_id] = n_z
+        if not hist:
+            n_z = _hist2dist(z, n_z)
+        out[bin_id] = n_z
 
-    return z, nz_dict
+    return z, out

--- a/tests/photo/test_phz.py
+++ b/tests/photo/test_phz.py
@@ -20,7 +20,7 @@ def test_redshift_distributions(tmp_path, write_hist, read_hist):
 
     path = tmp_path / "nz.fits"
 
-    el.photo._phz.write_nz(path, z, nz, hist=write_hist)
+    el.photo.redshift_distributions.write(path, z, nz, hist=write_hist)
 
     # read test data
 
@@ -46,7 +46,7 @@ def test_redshift_distributions_ident(tmp_path):
 
     path = tmp_path / "nz.fits"
 
-    el.photo._phz.write_nz(path, z_, nz_, hist=True)
+    el.photo.redshift_distributions.write(path, z_, nz_, hist=True)
     z, nz = el.photo.redshift_distributions(path, hist=True)
 
     np.testing.assert_array_equal(z, z_)

--- a/tests/photo/test_phz.py
+++ b/tests/photo/test_phz.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+import euclidlib as el
+
+
+@pytest.mark.parametrize("read_hist", [True, False])
+@pytest.mark.parametrize("write_hist", [True, False])
+def test_redshift_distributions(tmp_path, write_hist, read_hist):
+    def fn(z, hist):
+        """produce a mock n(z), optionally binned into a histogram"""
+        nz = np.exp(-((z - 1.0) ** 2) / (0.5) ** 2 / 2)
+        if hist:
+            nz = (nz[:-1] + nz[1:]) / 2 * np.diff(z)
+        return nz
+
+    # write test data from higher redshift resolution
+
+    z = np.linspace(0.0, 6.0, 10001)
+    nz = fn(z, write_hist)
+
+    path = tmp_path / "nz.fits"
+
+    el.photo._phz.write_nz(path, z, nz, hist=write_hist)
+
+    # read test data
+
+    z, nz = el.photo.redshift_distributions(path, hist=read_hist)
+
+    np.testing.assert_array_equal(z, np.linspace(0.0, 6.0, 3001))
+
+    assert len(nz) == 1
+    assert list(nz.keys()) == [1]
+
+    nz_ = fn(z, read_hist)
+    np.testing.assert_allclose(nz[1], nz_, rtol=0.01, atol=1e-4)

--- a/tests/photo/test_phz.py
+++ b/tests/photo/test_phz.py
@@ -15,7 +15,7 @@ def test_redshift_distributions(tmp_path, write_hist, read_hist):
         return nz
 
     # write test data from higher redshift resolution
-    z = np.linspace(0.0, 6.0, 6001)
+    z = np.linspace(0.0, 6.0, 10001)
     nz = fn(z, write_hist)
 
     path = tmp_path / "nz.fits"

--- a/tests/photo/test_phz.py
+++ b/tests/photo/test_phz.py
@@ -15,8 +15,7 @@ def test_redshift_distributions(tmp_path, write_hist, read_hist):
         return nz
 
     # write test data from higher redshift resolution
-
-    z = np.linspace(0.0, 6.0, 10001)
+    z = np.linspace(0.0, 6.0, 6001)
     nz = fn(z, write_hist)
 
     path = tmp_path / "nz.fits"
@@ -33,4 +32,22 @@ def test_redshift_distributions(tmp_path, write_hist, read_hist):
     assert list(nz.keys()) == [1]
 
     nz_ = fn(z, read_hist)
-    np.testing.assert_allclose(nz[1], nz_, rtol=0.01, atol=1e-4)
+    np.testing.assert_allclose(nz[1], nz_, rtol=1e-2, atol=1e-4)
+
+
+def test_redshift_distributions_ident(tmp_path):
+    """
+    Test that writing a histogram in the correct format returns the data
+    unchanged.
+    """
+    z_ = np.linspace(0.0, 6.0, 3001)
+    zmid = (z_[:-1] + z_[1:]) / 2
+    nz_ = np.exp(-((zmid - 1.0) ** 2) / (0.5) ** 2 / 2)
+
+    path = tmp_path / "nz.fits"
+
+    el.photo._phz.write_nz(path, z_, nz_, hist=True)
+    z, nz = el.photo.redshift_distributions(path, hist=True)
+
+    np.testing.assert_array_equal(z, z_)
+    np.testing.assert_array_equal(nz[1], nz_.astype(nz[1].dtype))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,17 @@
+import euclidlib as el
+
+
+def test_writable():
+    def func():
+        pass
+
+    func.__module__ = "mymodule"
+
+    @el._util.writer(func)
+    def writer():
+        pass
+
+    assert func.write is writer
+    assert func.write.__module__ == "mymodule"
+    assert func.write.__name__ == "write"
+    assert func.write.__qualname__ == f"{func.__qualname__}.write"


### PR DESCRIPTION
Updates the format of the photometric redshift distributions `el.photo.redshift_distributions()` and adds a simple test.

By default, the function now returns the n(z) distribution, instead of the histograms stored in the file.  The conversion is done by constructing the empirical CDF from the histograms, then taking the gradient to get the PDF.  A new `hist=` parameter can be used to return the histograms instead.

Also includes a `el.photo.redshift_distributions.write()` writer, which can similarly deal with distributions and histograms.  The function is tested, but I prefer we keep this as an internal API for the time being.

Closes: #14