### PR TITLE
gh-23: use np.trapezoid with NumPy 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # euclidlib
 
 ## Table of Contents
+
 - [Introduction](#introduction)
 - [Installation](#installation)
 - [Usage](#usage)
@@ -9,23 +10,29 @@
 - [Acknowledgements](#acknowledgements)
 
 ## Introduction
+
 `euclidlib` is an unofficial python package to read official Euclid mission products from the Science Ground Segment. The ultimate goal of `euclidlib` is to provide to the Euclid community a friendly and ready-to-use library that allows to work with the science-ready Euclid products right away. The library is maintained in a best-effort basis by Euclid volunteers and contributors. See acknolwedgements below.
 
 ## Installation
+
 As simple as:
-   ```sh
-   pip install euclidlib
-   ```
+
+```sh
+pip install euclidlib
+```
 
 ### Prerequisites
+
 - `python>3.7`
 - `fitsio`
 - `numpy`
 
 ## Usage
-Soon to be announced. 
+
+Soon to be announced.
 
 ## Contributing
+
 If you would like to contribute, follow the following steps:
 
 1. Open an issue to let the `euclidlib` maintainers know about your contribution plans (new Euclid product? New feature? A suggestion?)
@@ -44,7 +51,9 @@ If you would like to contribute, follow the following steps:
 5. Open a pull request
 
 ## License
+
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## Acknowledgements
-- Thanks to the `euclidlib` contributors so far: Will Hartley & Florian Dubath (redshift bin distribution schema), Felicitas Keil & Martin Kilbinger (photometric 2-point correlation functions reading routines), Nicolas Tessore (photometric power spectra reading routines)
+
+- Thanks to the `euclidlib` contributors so far: Will Hartley & Florian Dubath (redshift bin distribution schema), Felicitas Keil & Martin Kilbinger (photometric 2-point correlation functions reading routines), Nicolas Tessore (photometric power spectra reading routines).

--- a/euclidlib/_util.py
+++ b/euclidlib/_util.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from typing import Union
 import numpy as np
 from numpy.lib import NumpyVersion
 
@@ -29,7 +30,7 @@ def writer(func: Any) -> Callable[[AnyT], AnyT]:
 
     return decorator
 
-def trapezoidal_integration(y, x, axis=-1):
+def trapezoidal_integration(y: np.ndarray, x: np.ndarray = None, axis: int = -1) -> Union[float, np.ndarray]:
     """
     Compute the integral of `y` values using the trapezoidal rule.
 
@@ -55,8 +56,15 @@ def trapezoidal_integration(y, x, axis=-1):
         Definite integral as approximated by the trapezoidal rule.
     """
     if NumpyVersion(np.__version__) >= NumpyVersion('2.0.0'):
-        # NumPy version is 2.0.0' or later
-        return np.trapezoid(y, x, axis=axis)
+        # NumPy version is 2.0.0 or later
+        if hasattr(np, 'trapezoid'):
+            return np.trapezoid(y, x, axis=axis)
+        else:
+            raise AttributeError("NumPy version is >= 2.0.0 but 'trapezoid' function is not available.")
     else:
-        # NumPy version is older than 2.0.0'
-        return np.trapz(y, x, axis=axis)
+        # NumPy version is older than 2.0.0
+        if hasattr(np, 'trapz'):
+            return np.trapz(y, x, axis=axis)
+        else:
+            raise AttributeError("NumPy version is < 2.0.0 and 'trapz' function is not available.")
+

--- a/euclidlib/_util.py
+++ b/euclidlib/_util.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+from numpy.lib import NumpyVersion
+
 if TYPE_CHECKING:
     from typing import Any, Callable, TypeVar
 
@@ -25,3 +28,35 @@ def writer(func: Any) -> Callable[[AnyT], AnyT]:
         return writer
 
     return decorator
+
+def trapezoidal_integration(y, x, axis=-1):
+    """
+    Compute the integral of `y` values using the trapezoidal rule.
+
+    This function uses `np.trapezoid` if available (NumPy version 2.0.0 or later),
+    otherwise it falls back to `np.trapz` for older versions of NumPy.
+
+    This function will be eventually deprecated as soon as NumPy version 2.0.0 
+    becomes popular enough.
+
+    Parameters
+    ----------
+    y : array_like
+        Input array to integrate.
+    x : array_like, optional
+        The sample points corresponding to the `y` values. If `x` is None, the
+        sample points are assumed to be evenly spaced.
+    axis : int, optional
+        The axis along which to integrate. Default is -1 (last axis).
+
+    Returns
+    -------
+    float or ndarray
+        Definite integral as approximated by the trapezoidal rule.
+    """
+    if NumpyVersion(np.__version__) >= NumpyVersion('2.0.0'):
+        # NumPy version is 2.0.0' or later
+        return np.trapezoid(y, x, axis=axis)
+    else:
+        # NumPy version is older than 2.0.0'
+        return np.trapz(y, x, axis=axis)

--- a/euclidlib/_util.py
+++ b/euclidlib/_util.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from typing import Union, Optional
 import numpy as np
 from numpy.lib import NumpyVersion
+from typing import Union, Optional
 
 if TYPE_CHECKING:
     from typing import Any, Callable, TypeVar
@@ -33,32 +33,26 @@ def writer(func: Any) -> Callable[[AnyT], AnyT]:
 def trapezoidal_integration(y: np.ndarray, x: Optional[np.ndarray] = None, axis: int = -1) -> Union[float, np.ndarray]:
     """
     Compute the integral of `y` values using the trapezoidal rule.
-
-    This function uses `np.trapezoid` if available (NumPy version 2.0.0 or later),
-    otherwise it falls back to `np.trapz` for older versions of NumPy.
-
-    This function will be eventually deprecated as soon as NumPy version 2.0.0 
-    becomes popular enough.
-
+    
     Parameters
     ----------
-    y : array_like
+    y : np.ndarray
         Input array to integrate.
-    x : array_like, optional
+    x : Optional[np.ndarray], optional
         The sample points corresponding to the `y` values. If `x` is None, the
         sample points are assumed to be evenly spaced.
     axis : int, optional
         The axis along which to integrate. Default is -1 (last axis).
-
+    
     Returns
     -------
-    float or ndarray
+    float or np.ndarray
         Definite integral as approximated by the trapezoidal rule.
     """
     if NumpyVersion(np.__version__) >= NumpyVersion('2.0.0'):
         # NumPy version is 2.0.0 or later
         if hasattr(np, 'trapezoid'):
-            return np.trapezoid(y, x, axis=axis)
+            return np.trapezoid(y, x, axis=axis)  # Ensure that `np.trapezoid` exists
         else:
             raise AttributeError("NumPy version is >= 2.0.0 but 'trapezoid' function is not available.")
     else:
@@ -67,4 +61,4 @@ def trapezoidal_integration(y: np.ndarray, x: Optional[np.ndarray] = None, axis:
             return np.trapz(y, x, axis=axis)
         else:
             raise AttributeError("NumPy version is < 2.0.0 and 'trapz' function is not available.")
-
+        

--- a/euclidlib/_util.py
+++ b/euclidlib/_util.py
@@ -6,10 +6,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
-from numpy.lib import NumpyVersion
-from typing import Union, Optional
-
 if TYPE_CHECKING:
     from typing import Any, Callable, TypeVar
 
@@ -29,37 +25,3 @@ def writer(func: Any) -> Callable[[AnyT], AnyT]:
         return writer
 
     return decorator
-
-def trapezoidal_integration(y: np.ndarray[Any, Any], x: Optional[np.ndarray[Any, Any]] = None, axis: int = -1) -> Union[float, np.ndarray[Any, Any]]:
-    """
-    Compute the integral of `y` values using the trapezoidal rule.
-    
-    Parameters
-    ----------
-    y : np.ndarray
-        Input array to integrate.
-    x : Optional[np.ndarray], optional
-        The sample points corresponding to the `y` values. If `x` is None, the
-        sample points are assumed to be evenly spaced.
-    axis : int, optional
-        The axis along which to integrate. Default is -1 (last axis).
-    
-    Returns
-    -------
-    float or np.ndarray
-        Definite integral as approximated by the trapezoidal rule.
-    """
-    result: Union[float, np.ndarray[Any, Any]]
-    
-    if NumpyVersion(np.__version__) >= NumpyVersion('2.0.0'):
-        # NumPy version is 2.0.0 or later
-        if hasattr(np, 'trapezoid'):
-            result = np.trapezoid(y, x, axis=axis)  # Ensure that `np.trapezoid` exists
-        else:
-            raise AttributeError("NumPy version is >= 2.0.0 but 'trapezoid' function is not available.")
-    else:
-        # NumPy version is older than 2.0.0
-        result = np.trapz(y, x, axis=axis)
-    
-    return result
-        

--- a/euclidlib/_util.py
+++ b/euclidlib/_util.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from typing import Union
+from typing import Union, Optional
 import numpy as np
 from numpy.lib import NumpyVersion
 
@@ -30,7 +30,7 @@ def writer(func: Any) -> Callable[[AnyT], AnyT]:
 
     return decorator
 
-def trapezoidal_integration(y: np.ndarray, x: np.ndarray = None, axis: int = -1) -> Union[float, np.ndarray]:
+def trapezoidal_integration(y: np.ndarray, x: Optional[np.ndarray] = None, axis: int = -1) -> Union[float, np.ndarray]:
     """
     Compute the integral of `y` values using the trapezoidal rule.
 

--- a/euclidlib/_util.py
+++ b/euclidlib/_util.py
@@ -49,16 +49,17 @@ def trapezoidal_integration(y: np.ndarray[Any, Any], x: Optional[np.ndarray[Any,
     float or np.ndarray
         Definite integral as approximated by the trapezoidal rule.
     """
+    result: Union[float, np.ndarray[Any, Any]]
+    
     if NumpyVersion(np.__version__) >= NumpyVersion('2.0.0'):
         # NumPy version is 2.0.0 or later
         if hasattr(np, 'trapezoid'):
-            return np.trapezoid(y, x, axis=axis)  # Ensure that `np.trapezoid` exists
+            result = np.trapezoid(y, x, axis=axis)  # Ensure that `np.trapezoid` exists
         else:
             raise AttributeError("NumPy version is >= 2.0.0 but 'trapezoid' function is not available.")
     else:
         # NumPy version is older than 2.0.0
-        if hasattr(np, 'trapz'):
-            return np.trapz(y, x, axis=axis)
-        else:
-            raise AttributeError("NumPy version is < 2.0.0 and 'trapz' function is not available.")
+        result = np.trapz(y, x, axis=axis)
+    
+    return result
         

--- a/euclidlib/_util.py
+++ b/euclidlib/_util.py
@@ -30,7 +30,7 @@ def writer(func: Any) -> Callable[[AnyT], AnyT]:
 
     return decorator
 
-def trapezoidal_integration(y: np.ndarray, x: Optional[np.ndarray] = None, axis: int = -1) -> Union[float, np.ndarray]:
+def trapezoidal_integration(y: np.ndarray[Any, Any], x: Optional[np.ndarray[Any, Any]] = None, axis: int = -1) -> Union[float, np.ndarray[Any, Any]]:
     """
     Compute the integral of `y` values using the trapezoidal rule.
     

--- a/euclidlib/photo/_phz.py
+++ b/euclidlib/photo/_phz.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import fitsio  # type: ignore [import-not-found]
 import numpy as np
 
-from .._util import writer
+from .._util import writer, trapezoidal_integration
 
 if TYPE_CHECKING:
     from typing import Any
@@ -145,7 +145,8 @@ def _(
         # integrate the n(z) over each histogram bin
 
         # compute mean redshifts
-        out["MEAN_REDSHIFT"] = np.trapz(z * nz, z, axis=-1) / np.trapz(nz, z, axis=-1)
+        out["MEAN_REDSHIFT"] = \
+            trapezoidal_integration(z * nz, z, axis=-1) / trapezoidal_integration(nz, z, axis=-1)
 
         # compute the combined set of z grid points from data and binning
         zp = np.union1d(z, zbinedges)
@@ -158,7 +159,7 @@ def _(
             # integrate the distribution over each bin
             for j, (z1, z2) in enumerate(zip(zbinedges, zbinedges[1:])):
                 sel = (z1 <= zp) & (zp <= z2)
-                out["N_Z"][i, j] = np.trapz(nzp[sel], zp[sel])
+                out["N_Z"][i, j] = trapezoidal_integration(nzp[sel], zp[sel])
 
     # metadata
     header = {


### PR DESCRIPTION
## Description

Implemented a new function in `_util.py` that choses between `np.trapz` and `np.trapezoid` giving the NumPy version.

Closes #23 

## PR Checklist for maintainers

- [ ] PR targets the correct branch
- [ ] Tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [ ] Check that the names of the new functions are homogenous with the rest of the code in `euclidlib`
- [ ] Check that the output of the new reading function(s) follows the agreed interal format of `euclidlib` 
- [ ] Check that an example of how to use the new function(s) have been added to the documentation 
