### PR TITLE
gh-26: remove default extension name for n(z) reading

### DIFF
--- a/euclidlib/photo/_phz.py
+++ b/euclidlib/photo/_phz.py
@@ -33,7 +33,7 @@ def _hist2dist(x: NDArray[Any], y: NDArray[Any]) -> NDArray[Any]:
 def redshift_distributions(
     path: str | PathLike[str],
     *,
-    ext: str | int | None = "BIN_INFO",
+    ext: str | int | None = None,
     hist: bool = False,
 ) -> tuple[NDArray[Any], Mapping[int, NDArray[Any]]]:
     """Read redshift distributions in Euclid format.


### PR DESCRIPTION
Remove the default `"BIN_INFO"` extension name from the `el.photo.redshift_distributions()` reader. This means the first extension with data is used by default.

Closes: #26