### PR TITLE
gh-72: Don't force PK-WL results to float dtype

### DIFF
--- a/euclidlib/photo/_le3_pk_wl.py
+++ b/euclidlib/photo/_le3_pk_wl.py
@@ -51,10 +51,6 @@ class Result:
     weight: NDArray[Any] | tuple[NDArray[Any], ...] | None = None
 
     def __post_init__(self) -> None:
-        # Ensure array is of float dtype
-        float_array = np.asarray(self.array, dtype=float)
-        object.__setattr__(self, "array", float_array)
-
         # Normalize the axis after setting the array
         axis = normalize_result_axis(self.axis, self.array, self.ell)
         object.__setattr__(self, "axis", axis)


### PR DESCRIPTION
This fixes a bug where we lose metadata when the array dtype is forced to float.

## 📌 Related Issue

<!-- Link to the issue this PR is addressing, e.g., "Closes #42" -->

Closes #72

## ✨ What’s been added or changed?

## <!-- Summarize the key changes or features introduced in this PR -->

## 🧪 How was it tested?

## <!-- Describe how you verified the change works (unit tests, notebooks, CLI runs, etc.) -->

## 📸 Screenshots (if applicable)

## <!-- Add before/after screenshots or logs if the changes affect the UI or output -->

## 🧠 Anything to keep in mind?

## <!-- Note anything relevant like known issues, limitations, or design decisions -->

<<<<<<< HEAD

## 🔍 Checklist for developers

=======

## 🔍 Checklist

> > > > > > > 5388340425dcb1e6069a657f0cf6ed5abe7e57ff

<!-- Check off what you've done before submitting the PR -->

- [ ] I've named the title of this pull request starting by 'gh-#: TITLE'
- [ ] I’ve linked the related issue
- [ ] I’ve tested the code manually
- [ ] I’ve added comments/docstrings where needed (i.e: README)
- [ ] I’ve updated relevant docs if necessary
- [ ] I've checked that there are no breaking changes in the interface/api
- [ ] I’ve added corresponding unit tests

## 🎯 Checklist for maintainers

- -- [ ] PR targets the correct branch
  -- [ ] Tests have run and passed for the latest commit on the source branch
  -- [ ] Check that the code can still be installed if new packages are imported
  -- [ ] Quality of new/changed code is acceptable
  -- [ ] Quality of new/changed unit tests is acceptable
  -- [ ] Check that the names of the new functions are homogenous with the rest of the code in `euclidlib`
