### PR TITLE
gh-138: Fix extname bug

### DIFF
--- a/euclidlib/le3/twopcf_wl.py
+++ b/euclidlib/le3/twopcf_wl.py
@@ -395,7 +395,7 @@ def _(path: str | PathLike[str], results: dict[_DictKey, COSEBI]) -> None:
                 raise ValueError("COSEBI writer supports only SHE-SHE components.")
 
             # EXTNAME like SHEARSHEAR2D_COSEBI_1_1
-            extname = f"    {bin1}_{bin2}"
+            extname = f"SHEARSHEAR2D_COSEBI_{bin1}_{bin2}"
 
             # Extract arrays
             mode = np.asarray(cosebi.mode, dtype="i8")


### PR DESCRIPTION
## 📌 Related Issue

<!-- Link to the issue this PR is addressing, e.g., "Closes #42" -->

Closes #138 

## ✨ What’s been added or changed?

updated the extname to be of the format "SHEARSHEAR2D_COSEBI_{bin1}_{bin2}"

## 🧪 How was it tested?

<!-- Describe how you verified the change works (unit tests, notebooks, CLI runs, etc.) -->

## 📸 Screenshots (if applicable)

<!-- Add before/after screenshots or logs if the changes affect the UI or output -->

## 🧠 Anything to keep in mind?

<!-- Note anything relevant like known issues, limitations, or design decisions -->

## 🔍 Checklist for developers

<!-- Check off what you've done before submitting the PR -->

- [x] I've named the title of this pull request starting by 'gh-#: TITLE'
- [x] I’ve linked the related issue
- [ ] I’ve tested the code manually
- [ ] I’ve added comments/docstrings where needed (i.e: README)
- [ ] I’ve updated relevant docs if necessary
- [ ] I've checked that there are no breaking changes in the interface/api
- [ ] I’ve added corresponding unit tests

## 🎯 Checklist for maintainers

- [ ] PR targets the correct branch
- [ ] Tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [ ] Check that the names of the new functions are homogenous with the rest of the code in `euclidlib`
