### PR TITLE
gh-155: add kcenter while reading gcspectro mixing matrix

### DIFF
--- a/euclidlib/le3/pk_gc.py
+++ b/euclidlib/le3/pk_gc.py
@@ -265,8 +265,9 @@ def power_spectrum_multipole_mixing_matrix(
 
     for i, zlab in enumerate(redshifts):
         header, data = read_mixing_matrix(str(path).format(zlab))
-        kout = data["BINS_OUTPUT"]["k"]
-        kcenter = data["BINS_OUTPUT"]["kcenter"]
+        out = data["BINS_OUTPUT"]
+        kout = out["k"]
+        kcenter = out["kcenter"] if "kcenter" in out.dtype.names else kout
         kin = {ell: data["BINS_INPUT"]["kp{}".format(ell)] for ell in even_multipoles}
         mixing_matrix_blocks = {
             "ELL_{}-{}".format(ell1, ell2): data["MIXING_MATRIX"][

--- a/euclidlib/le3/pk_gc.py
+++ b/euclidlib/le3/pk_gc.py
@@ -266,8 +266,10 @@ def power_spectrum_multipole_mixing_matrix(
     for i, zlab in enumerate(redshifts):
         header, data = read_mixing_matrix(str(path).format(zlab))
         out = data["BINS_OUTPUT"]
+        names = out.dtype.names
         kout = out["k"]
-        kcenter = out["kcenter"] if "kcenter" in out.dtype.names else kout
+        has_kcenter = names is not None and "kcenter" in names
+        kcenter = out["kcenter"] if has_kcenter else kout
         kin = {ell: data["BINS_INPUT"]["kp{}".format(ell)] for ell in even_multipoles}
         mixing_matrix_blocks = {
             "ELL_{}-{}".format(ell1, ell2): data["MIXING_MATRIX"][

--- a/euclidlib/le3/pk_gc.py
+++ b/euclidlib/le3/pk_gc.py
@@ -266,6 +266,7 @@ def power_spectrum_multipole_mixing_matrix(
     for i, zlab in enumerate(redshifts):
         header, data = read_mixing_matrix(str(path).format(zlab))
         kout = data["BINS_OUTPUT"]["k"]
+        kcenter = data["BINS_OUTPUT"]["kcenter"]
         kin = {ell: data["BINS_INPUT"]["kp{}".format(ell)] for ell in even_multipoles}
         mixing_matrix_blocks = {
             "ELL_{}-{}".format(ell1, ell2): data["MIXING_MATRIX"][
@@ -284,7 +285,7 @@ def power_spectrum_multipole_mixing_matrix(
             zeff = 0.0
 
         results[("SPE", "SPE", i, i)] = PowerSpectrumMultipolesMixingMatrix(
-            kout=kout, kin=kin, mixing=mixing_matrix_blocks, zeff=zeff
+            kout=kout, kcenter=kcenter, kin=kin, mixing=mixing_matrix_blocks, zeff=zeff
         )
 
     return results


### PR DESCRIPTION
## 📌 Related Issue

Closes #155

## ✨ What’s been added or changed?

Added reading of kcenter in GCspectro mixing matrix

## 🧪 How was it tested?

Reading LE3 fits file with and without kcenter

## 🔍 Checklist for developers

<!-- Check off what you've done before submitting the PR -->

- [ ] I've named the title of this pull request starting by 'gh-#: TITLE'
- [ ] I’ve linked the related issue
- [ ] I’ve tested the code manually
- [ ] I’ve added comments/docstrings where needed (i.e: README)
- [ ] I’ve updated relevant docs if necessary
- [ ] I've checked that there are no breaking changes in the interface/api
- [ ] I’ve added corresponding unit tests

## 🎯 Checklist for maintainers

- [ ] PR targets the correct branch
- [ ] Tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [ ] Check that the names of the new functions are homogenous with the rest of the code in `euclidlib`
